### PR TITLE
No c++98 warnings

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -22,7 +22,7 @@ add_compile_definitions(HAVE_CONFIG_H PARPAR_ENABLE_HASHER_MD5CRC)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
-        add_compile_options(-Weverything)
+        add_compile_options(-Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         add_compile_options(-Wall -Wextra)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
The CMakeFiles.txt is configured to use C++17:
https://github.com/nzbgetcom/par2cmdline-turbo/blob/445cb2999f78a58e35064311510b142c6586eb21/CMakeLists.txt#L31

So specifying `-Weverything` is overkill as that will include warnings for compatibility back to C++98.
The current warning count is too large to be actionable:
![Capture d’écran 2025-06-16 à 01 21 27](https://github.com/user-attachments/assets/5f6d7d16-55b2-4ea2-aa7a-c3addb558136)

At least, removing the C++98 compatibility warnings will help remove a few hundreds of them.
And unless we really have a goal to fix those thousands of warnings, I might suggest to stick to `-Wall -Wextra` instead of `-Weverything`.