### PR TITLE
Large files (size >32 bit) treated as if they do not exist

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -81,8 +81,8 @@ bool DiskFile::CreateParentDirectory(string _pathname)
     auto wpath = Utf8ToWide(path);
     if (!wpath.has_value()) return false;
 
-    struct _stat st;
-    if (_wstat(wpath->c_str(), &st) == 0)
+    struct _stat64 st;
+    if (_wstat64(wpath->c_str(), &st) == 0)
       return true; // let the caller deal with non-directories
 
     if (!DiskFile::CreateParentDirectory(path))
@@ -404,8 +404,8 @@ u64 DiskFile::GetFileSize(string filename)
   auto wfilename = Utf8ToWide(filename);
   if (!wfilename.has_value()) return 0;
 
-  struct _stati64 st;
-  if ((0 == _wstati64(wfilename->c_str(), &st)) && (0 != (st.st_mode & S_IFREG)))
+  struct _stat64 st;
+  if ((0 == _wstat64(wfilename->c_str(), &st)) && (0 != (st.st_mode & S_IFREG)))
   {
     return st.st_size;
   }
@@ -420,8 +420,8 @@ bool DiskFile::FileExists(string filename)
   auto wfilename = Utf8ToWide(filename);
   if (!wfilename.has_value()) return false;
 
-  struct _stati64 st;
-  return ((0 == _wstati64(wfilename->c_str(), &st)) && (0 != (st.st_mode & _S_IFREG)));
+  struct _stat64 st;
+  return ((0 == _wstat64(wfilename->c_str(), &st)) && (0 != (st.st_mode & _S_IFREG)));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -420,8 +420,8 @@ bool DiskFile::FileExists(string filename)
   auto wfilename = Utf8ToWide(filename);
   if (!wfilename.has_value()) return false;
 
-  struct _stat st;
-  return ((0 == _wstat(wfilename->c_str(), &st)) && (0 != (st.st_mode & _S_IFREG)));
+  struct _stati64 st;
+  return ((0 == _wstati64(wfilename->c_str(), &st)) && (0 != (st.st_mode & _S_IFREG)));
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/libpar2internal.h
+++ b/src/libpar2internal.h
@@ -41,7 +41,7 @@
 #define sprintf  sprintf_s
 #define stricmp  _stricmp
 #define unlink   _unlink
-#define stat _stat
+#define stat _stat64
 
 #define __LITTLE_ENDIAN 1234
 #define __BIG_ENDIAN    4321


### PR DESCRIPTION
Commit bbacdb7 introduced a regression by [changing](https://github.com/animetosho/par2cmdline-turbo/commit/bbacdb7636cf1a687cfc66fac0d7cbe40ccdc028#diff-fb5cfbb607409415f4f3c9981b98438d15cbba17986cfa3164d45d4085d7bfb0R408-R409) `_wstati64()` to `_wstat()` in `DiskFile::FileExists()`. Files with sizes that do not fit in 32 bits cause `_wstat()` to fail with `EOVERFLOW`. (Although that is never clearly stated in the [docs](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?view=msvc-170).)

In the first commit, I just changed it back to `_wstati64()`.

The second commit prevents two similar issues:

- `DiskFile::CreateParentDirectory()` was also using `_wstat()`.
- `DiskFile::Rename()` uses `stat()` for platform independence. On Windows, `stat` was defined to `_stat`. System headers turn `_stat` into `_stat64i32`—which uses 32-bit sizes.

`Rename()` doesn't use wide characters, so I changed the definition of `stat` to `_stat64`.

I also converted every other stat call to `_wstat64()`, which explicitly supports 64-bit sizes and 64-bit times regardless of `_USE_32BIT_TIME_T`. It prevents any future overflow issues in the (granted, unlikely) case that `_USE_32BIT_TIME_T` is defined, since the times are never accessed anyway.

The second commit may (at least partially) belong upstream; please let me know if I should submit it there instead. (I may decide to do that on my own.)
