### PR TITLE
Fix gcc build error, leak and names in SigDone

### DIFF
--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -394,7 +394,7 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
 
   std::string pathWithWildcard = path + wildcard;
   auto wwildcard = utf8::Utf8ToWide(pathWithWildcard);
-  if (!wwildcard) return false;
+  if (!wwildcard) return nullptr;
   WIN32_FIND_DATAW fd;
   HANDLE h = ::FindFirstFileW(wwildcard->c_str(), &fd);
   if (h != INVALID_HANDLE_VALUE)

--- a/src/diskfile.cpp
+++ b/src/diskfile.cpp
@@ -390,11 +390,12 @@ std::unique_ptr< std::list<std::string> > DiskFile::FindFiles(std::string path, 
   {
     path += PATHSEP;
   }
-  std::list<std::string> *matches = new std::list<std::string>;
 
   std::string pathWithWildcard = path + wildcard;
   auto wwildcard = utf8::Utf8ToWide(pathWithWildcard);
   if (!wwildcard) return nullptr;
+
+  std::list<std::string> *matches = new std::list<std::string>;
   WIN32_FIND_DATAW fd;
   HANDLE h = ::FindFirstFileW(wwildcard->c_str(), &fd);
   if (h != INVALID_HANDLE_VALUE)

--- a/src/par2repairer.cpp
+++ b/src/par2repairer.cpp
@@ -1667,7 +1667,7 @@ bool Par2Repairer::ScanDataFile(DiskFile                *diskfile,    // [in]
   }
   else
   {
-    shortname = std::move(name);
+    shortname = name;
   }
 
   // Create the checksummer for the file and start reading from it


### PR DESCRIPTION
I've been looking at using your fork in a certain Python application, I ran into a couple of minor issues that required local patches but it would be nice to upstream them.

`if (!wwildcard) return false;` fails on GCC (MinGW) although I'm not using it, it still seemed worth fixing.
Additionally, if that early return is taken `matches` leaks.

Perhaps this doesn't affect nzbget but `std::move(name)` steals the name so the future `SigDone(name, ...)` calls have empty names when the name is less than 56 characters.

Note I have not tested the impact of these changes within an nzbget build, but I don't foresee any issue.